### PR TITLE
chore: fixed type errors in xgboost.py

### DIFF
--- a/src/random_tree_models/xgboost.py
+++ b/src/random_tree_models/xgboost.py
@@ -106,7 +106,7 @@ def xgboost_histogrammify_with_h(
 
         rank_bin_edges = np.histogram_bin_edges(rank, bins=n_bins)
         bin_assignments = pd.cut(
-            rank, bins=rank_bin_edges, labels=False, include_lowest=True
+            rank, bins=rank_bin_edges.tolist(), labels=False, include_lowest=True
         )
 
         x_bin_edges = np.interp(rank_bin_edges, rank, x_ordered)
@@ -126,7 +126,7 @@ def xgboost_histogrammify_with_x_bin_edges(
 
     for i in range(X.shape[1]):
         bin_assignments = pd.cut(
-            X[:, i], bins=all_x_bin_edges[i], labels=False, include_lowest=True
+            X[:, i], bins=all_x_bin_edges[i].tolist(), labels=False, include_lowest=True
         )
 
         X_hist[:, i] = bin_assignments


### PR DESCRIPTION
This pull request makes a minor update to the way bin edges are passed to `pd.cut` in the `xgboost.py` module. The change ensures compatibility by converting numpy arrays of bin edges to Python lists before passing them to `pd.cut`.

- Compatibility improvements:
  * In both `xgboost_histogrammify_with_h` and `xgboost_histogrammify_with_x_bin_edges`, bin edge arrays are now converted to lists using `.tolist()` before being used as the `bins` parameter in `pd.cut`. [[1]](diffhunk://#diff-df7a850d9fe8f73bd541a32f7088f3acbfe3a5dfe46d478de8d12a7cc30ccbe5L109-R109) [[2]](diffhunk://#diff-df7a850d9fe8f73bd541a32f7088f3acbfe3a5dfe46d478de8d12a7cc30ccbe5L129-R129)