### PR TITLE
chore: moved tests from test_utils to test_params, and well fixed a b…

### DIFF
--- a/src/random_tree_models/decisiontree/estimators.py
+++ b/src/random_tree_models/decisiontree/estimators.py
@@ -5,11 +5,17 @@ import sklearn.base as base
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
 from sklearn.utils.validation import check_is_fitted, validate_data  # type: ignore
 
-import random_tree_models.params
 from random_tree_models.decisiontree.node import Node
 from random_tree_models.decisiontree.predict import predict_with_tree
 from random_tree_models.decisiontree.train import grow_tree
-from random_tree_models.params import MetricNames
+from random_tree_models.params import (
+    ColumnSelectionMethod,
+    ColumnSelectionParameters,
+    MetricNames,
+    ThresholdSelectionMethod,
+    ThresholdSelectionParameters,
+    TreeGrowthParameters,
+)
 
 
 class DecisionTreeTemplate(base.BaseEstimator):
@@ -19,32 +25,32 @@ class DecisionTreeTemplate(base.BaseEstimator):
     """
 
     max_depth: int
-    measure_name: random_tree_models.params.MetricNames
+    measure_name: MetricNames
     min_improvement: float
     lam: float
     frac_subsamples: float
     frac_features: float
     random_state: int
-    threshold_method: random_tree_models.params.ThresholdSelectionMethod
+    threshold_method: ThresholdSelectionMethod
     threshold_quantile: float
     n_thresholds: int
-    column_method: random_tree_models.params.ColumnSelectionMethod
+    column_method: ColumnSelectionMethod
     n_columns_to_try: int | None
     ensure_all_finite: bool
     tree_: Node
 
     def __init__(
         self,
-        measure_name: random_tree_models.params.MetricNames,
+        measure_name: MetricNames,
         max_depth: int = 2,
         min_improvement: float = 0.0,
         lam: float = 0.0,
         frac_subsamples: float = 1.0,
         frac_features: float = 1.0,
-        threshold_method: random_tree_models.params.ThresholdSelectionMethod = random_tree_models.params.ThresholdSelectionMethod.bruteforce,
+        threshold_method: ThresholdSelectionMethod = ThresholdSelectionMethod.bruteforce,
         threshold_quantile: float = 0.1,
         n_thresholds: int = 100,
-        column_method: random_tree_models.params.ColumnSelectionMethod = random_tree_models.params.ColumnSelectionMethod.ascending,
+        column_method: ColumnSelectionMethod = ColumnSelectionMethod.ascending,
         n_columns_to_try: int | None = None,
         random_state: int = 42,
         ensure_all_finite: bool = True,
@@ -64,20 +70,20 @@ class DecisionTreeTemplate(base.BaseEstimator):
         self.ensure_all_finite = ensure_all_finite
 
     def _organize_growth_parameters(self):
-        self.growth_params_ = random_tree_models.params.TreeGrowthParameters(
+        self.growth_params_ = TreeGrowthParameters(
             max_depth=self.max_depth,
             min_improvement=self.min_improvement,
             lam=-abs(self.lam),
             frac_subsamples=float(self.frac_subsamples),
             frac_features=float(self.frac_features),
             random_state=int(self.random_state),
-            threshold_params=random_tree_models.params.ThresholdSelectionParameters(
+            threshold_params=ThresholdSelectionParameters(
                 method=self.threshold_method,
                 quantile=self.threshold_quantile,
                 n_thresholds=self.n_thresholds,
                 random_state=int(self.random_state),
             ),
-            column_params=random_tree_models.params.ColumnSelectionParameters(
+            column_params=ColumnSelectionParameters(
                 method=self.column_method,
                 n_trials=self.n_columns_to_try,
             ),
@@ -142,10 +148,10 @@ class DecisionTreeRegressor(base.RegressorMixin, DecisionTreeTemplate):
         lam: float = 0.0,
         frac_subsamples: float = 1.0,
         frac_features: float = 1.0,
-        threshold_method: random_tree_models.params.ThresholdSelectionMethod = random_tree_models.params.ThresholdSelectionMethod.bruteforce,
+        threshold_method: ThresholdSelectionMethod = ThresholdSelectionMethod.bruteforce,
         threshold_quantile: float = 0.1,
         n_thresholds: int = 100,
-        column_method: random_tree_models.params.ColumnSelectionMethod = random_tree_models.params.ColumnSelectionMethod.ascending,
+        column_method: ColumnSelectionMethod = ColumnSelectionMethod.ascending,
         n_columns_to_try: int | None = None,
         random_state: int = 42,
         ensure_all_finite: bool = True,
@@ -215,10 +221,10 @@ class DecisionTreeClassifier(base.ClassifierMixin, DecisionTreeTemplate):
         lam: float = 0.0,
         frac_subsamples: float = 1.0,
         frac_features: float = 1.0,
-        threshold_method: random_tree_models.params.ThresholdSelectionMethod = random_tree_models.params.ThresholdSelectionMethod.bruteforce,
+        threshold_method: ThresholdSelectionMethod = ThresholdSelectionMethod.bruteforce,
         threshold_quantile: float = 0.1,
         n_thresholds: int = 100,
-        column_method: random_tree_models.params.ColumnSelectionMethod = random_tree_models.params.ColumnSelectionMethod.ascending,
+        column_method: ColumnSelectionMethod = ColumnSelectionMethod.ascending,
         n_columns_to_try: int | None = None,
         random_state: int = 42,
         ensure_all_finite: bool = True,

--- a/src/random_tree_models/gradientboostedtrees.py
+++ b/src/random_tree_models/gradientboostedtrees.py
@@ -15,6 +15,7 @@ from sklearn.utils.validation import (
 
 import random_tree_models.decisiontree as dtree
 from random_tree_models.params import MetricNames
+from random_tree_models.utils import bool_to_float
 
 
 class GradientBoostedTreesTemplate(base.BaseEstimator):
@@ -132,15 +133,6 @@ class GradientBoostedTreesRegressor(
             y += dy
 
         return y
-
-
-def bool_to_float(x: bool) -> float:
-    if x == True:
-        return 1.0
-    elif x == False:
-        return -1.0
-    else:
-        raise ValueError(f"{x=}, expected bool")
 
 
 class GradientBoostedTreesClassifier(

--- a/src/random_tree_models/utils.py
+++ b/src/random_tree_models/utils.py
@@ -19,3 +19,12 @@ def _get_logger(level=logging.INFO):
 
 
 logger = _get_logger()
+
+
+def bool_to_float(x: bool) -> float:
+    if x == True:
+        return 1.0
+    elif x == False:
+        return -1.0
+    else:
+        raise ValueError(f"{x=}, expected bool")

--- a/src/random_tree_models/xgboost.py
+++ b/src/random_tree_models/xgboost.py
@@ -27,7 +27,7 @@ from sklearn.utils.validation import (
 )
 
 import random_tree_models.decisiontree as dtree
-import random_tree_models.gradientboostedtrees as gbt
+import random_tree_models.utils as gbt
 from random_tree_models.params import MetricNames
 
 

--- a/tests/test_extratrees.py
+++ b/tests/test_extratrees.py
@@ -2,8 +2,11 @@ import numpy as np
 import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
-import random_tree_models.decisiontree as dtree
 import random_tree_models.extratrees as et
+from random_tree_models.decisiontree import (
+    DecisionTreeClassifier,
+    DecisionTreeRegressor,
+)
 from random_tree_models.params import MetricNames
 from tests.conftest import expected_failed_checks
 
@@ -37,9 +40,7 @@ class TestExtraTreesRegressor:
     def test_fit(self):
         model = et.ExtraTreesRegressor()
         model.fit(self.X, self.y)
-        assert all(
-            [isinstance(model, dtree.DecisionTreeRegressor) for model in model.trees_]
-        )
+        assert all([isinstance(model, DecisionTreeRegressor) for model in model.trees_])
 
     def test_predict(self):
         model = et.ExtraTreesRegressor()
@@ -69,7 +70,7 @@ class TestXGBoostClassifier:
         model.fit(self.X, self.y)
         assert not hasattr(self.model, "classes_")
         assert all(
-            [isinstance(model, dtree.DecisionTreeClassifier) for model in model.trees_]
+            [isinstance(model, DecisionTreeClassifier) for model in model.trees_]
         )
 
     def test_predict(self):

--- a/tests/test_gradientboostedtrees.py
+++ b/tests/test_gradientboostedtrees.py
@@ -2,8 +2,10 @@ import numpy as np
 import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
-import random_tree_models.decisiontree as dtree
 import random_tree_models.gradientboostedtrees as gbt
+from random_tree_models.decisiontree import (
+    DecisionTreeRegressor,
+)
 from tests.conftest import expected_failed_checks
 
 
@@ -36,9 +38,7 @@ class TestGradientBoostedTreesRegressor:
     def test_fit(self):
         model = gbt.GradientBoostedTreesRegressor()
         model.fit(self.X, self.y)
-        assert all(
-            [isinstance(model, dtree.DecisionTreeRegressor) for model in model.trees_]
-        )
+        assert all([isinstance(model, DecisionTreeRegressor) for model in model.trees_])
 
     def test_predict(self):
         model = gbt.GradientBoostedTreesRegressor()
@@ -67,9 +67,7 @@ class TestGradientBoostedTreesClassifier:
         model = gbt.GradientBoostedTreesClassifier()
         model.fit(self.X, self.y)
         assert not hasattr(self.model, "classes_")
-        assert all(
-            [isinstance(model, dtree.DecisionTreeRegressor) for model in model.trees_]
-        )
+        assert all([isinstance(model, DecisionTreeRegressor) for model in model.trees_])
 
     def test_predict(self):
         model = gbt.GradientBoostedTreesClassifier()
@@ -88,28 +86,3 @@ def test_gbt_estimators_with_sklearn_checks(estimator, check):
     Reference: https://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.parametrize_with_checks.html#sklearn.utils.estimator_checks.parametrize_with_checks
     """
     check(estimator)
-
-
-@pytest.mark.parametrize(
-    "x,exp,is_bad",
-    [
-        (True, 1, False),
-        (False, -1, False),
-        ("a", None, True),
-        (1, 1, False),
-        (0, -1, False),
-        (-1, None, True),
-        (None, None, True),
-    ],
-)
-def test_bool_to_float(x, exp, is_bad: bool):
-    try:
-        # line to test
-        res = gbt.bool_to_float(x)
-    except ValueError as ex:
-        if is_bad:
-            pass  # Failed expectedly to convert non-bool values
-    else:
-        if is_bad:
-            pytest.fail(f"Passed unexpectedly for non-bool value {x} returning {res}")
-        assert res == exp

--- a/tests/test_leafweights.py
+++ b/tests/test_leafweights.py
@@ -2,8 +2,7 @@ import numpy as np
 import pytest
 
 import random_tree_models.leafweights as leafweights
-import random_tree_models.params as utils
-from random_tree_models.params import MetricNames
+from random_tree_models.params import MetricNames, TreeGrowthParameters
 
 
 def test_leaf_weight_mean():
@@ -19,14 +18,14 @@ def test_leaf_weight_binary_classification_friedman2001():
 def test_leaf_weight_xgboost():
     g = np.array([1, 2, 3]) * 2
     h = np.array([1, 2, 3]) * 4
-    params = utils.TreeGrowthParameters(max_depth=2, lam=0.0)
+    params = TreeGrowthParameters(max_depth=2, lam=0.0)
     assert leafweights.leaf_weight_xgboost(g=g, h=h, growth_params=params) == -0.5
 
 
 class Test_calc_leaf_weight:
     def test_error_for_unknown_scheme(self):
         y = np.array([1, 2, 3])
-        growth_params = utils.TreeGrowthParameters(max_depth=2, lam=0.0)
+        growth_params = TreeGrowthParameters(max_depth=2, lam=0.0)
         with pytest.raises(NotImplementedError):
             leafweights.calc_leaf_weight(
                 y=y,
@@ -36,7 +35,7 @@ class Test_calc_leaf_weight:
 
     def test_leaf_weight_none_if_y_empty(self):
         y = np.array([])
-        growth_params = utils.TreeGrowthParameters(max_depth=2, lam=0.0)
+        growth_params = TreeGrowthParameters(max_depth=2, lam=0.0)
 
         weight = leafweights.calc_leaf_weight(
             y=y, growth_params=growth_params, measure_name=MetricNames.gini
@@ -45,7 +44,7 @@ class Test_calc_leaf_weight:
 
     def test_leaf_weight_float_if_y_not_empty(self):
         y = np.array([1, 2, 3])
-        growth_params = utils.TreeGrowthParameters(max_depth=2, lam=0.0)
+        growth_params = TreeGrowthParameters(max_depth=2, lam=0.0)
 
         weight = leafweights.calc_leaf_weight(
             y=y, growth_params=growth_params, measure_name=MetricNames.variance

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,216 @@
+import pytest
+from pydantic import ValidationError
+
+from random_tree_models.params import (
+    ColumnSelectionMethod,
+    ColumnSelectionParameters,
+    ThresholdSelectionMethod,
+    ThresholdSelectionParameters,
+    TreeGrowthParameters,
+)
+
+
+def test_ColumnSelectionMethod():
+    expected = ["ascending", "largest_delta", "random"]
+    assert list(ColumnSelectionMethod.__members__.keys()) == expected
+
+
+def test_ThresholdSelectionMethod():
+    expected = ["bruteforce", "quantile", "random", "uniform"]
+    assert list(ThresholdSelectionMethod.__members__.keys()) == expected
+
+
+# method, quantile, random_state, n_thresholds
+class TestThresholdSelectionParameters:
+    def test_expected_okay(self):
+        params = ThresholdSelectionParameters(
+            method=ThresholdSelectionMethod.quantile,
+            quantile=0.1,
+            random_state=0,
+            n_thresholds=100,
+        )
+        assert params.method == ThresholdSelectionMethod.quantile
+        assert params.quantile == 0.1
+        assert params.random_state == 0
+        assert params.n_thresholds == 100
+        assert params.num_quantile_steps == 11
+
+    def test_method_fail(self):
+        try:
+            _ = ThresholdSelectionParameters(
+                method="wuppy",  # type: ignore
+                quantile=0.1,
+                random_state=0,
+                n_thresholds=100,
+            )
+        except ValueError:
+            pass  # f"init with unknown method should fail: {ex}"
+        else:
+            raise
+
+    @pytest.mark.parametrize(
+        "q,fail",
+        [(-0.1, True), (0.0, True), (0.5, False), (1.0, True), (1.1, True)],
+    )
+    def test_quantile(self, q: float, fail: bool):
+        try:
+            _ = ThresholdSelectionParameters(
+                method=ThresholdSelectionMethod.quantile,
+                quantile=q,
+                random_state=0,
+                n_thresholds=100,
+            )
+        except ValueError as ex:
+            if fail:
+                pass  # f"init with quantile {q} should fail: {ex}"
+            else:
+                pytest.fail(f"init with quantile {q} should fail: {ex}")
+        else:
+            if fail:
+                raise
+
+    @pytest.mark.parametrize(
+        "random_state,fail",
+        [
+            (-1, True),
+            (0, False),
+            (1, False),
+        ],
+    )
+    def test_random_state(self, random_state: int, fail: bool):
+        try:
+            _ = ThresholdSelectionParameters(
+                method=ThresholdSelectionMethod.quantile,
+                quantile=0.1,
+                random_state=random_state,
+                n_thresholds=100,
+            )
+        except ValueError as ex:
+            if fail:
+                pass  # f"init with {random_state=} should fail: {ex}"
+            else:
+                pytest.fail(f"init with {random_state=} should fail: {ex}")
+        else:
+            if fail:
+                pytest.fail(f"init with {random_state=} should fail")
+
+    @pytest.mark.parametrize(
+        "n_thresholds,fail",
+        [
+            (-1, True),
+            (0, True),
+            (
+                1,
+                False,
+            ),
+            (10, False),
+        ],
+    )
+    def test_n_thresholds(self, n_thresholds: int, fail: bool):
+        try:
+            _ = ThresholdSelectionParameters(
+                method=ThresholdSelectionMethod.quantile,
+                quantile=0.1,
+                random_state=42,
+                n_thresholds=n_thresholds,
+            )
+        except ValueError as ex:
+            if fail:
+                pass  # f"init with {n_thresholds=} should fail: {ex}"
+            else:
+                pytest.fail(f"init with {n_thresholds=} should fail: {ex}")
+        else:
+            if fail:
+                raise
+
+
+def test_ColumnSelectionParameters():
+    params = ColumnSelectionParameters(method=ColumnSelectionMethod.random, n_trials=10)
+    assert params.method == ColumnSelectionMethod.random
+    assert params.n_trials == 10
+
+
+class TestTreeGrowthParameters:
+    def test_expected_okay(self):
+        params = TreeGrowthParameters(
+            max_depth=10,
+            min_improvement=0.0,
+            lam=0.0,
+            frac_subsamples=1.0,
+            frac_features=1.0,
+            random_state=0,
+            threshold_params=ThresholdSelectionParameters(
+                method=ThresholdSelectionMethod.quantile,
+                quantile=0.1,
+                random_state=0,
+                n_thresholds=100,
+            ),
+            column_params=ColumnSelectionParameters(
+                method=ColumnSelectionMethod.random, n_trials=10
+            ),
+        )
+        assert params.max_depth == 10
+        assert params.min_improvement == 0.0
+        assert params.lam == 0.0
+        assert params.frac_subsamples == 1.0
+        assert params.frac_features == 1.0
+        assert params.random_state == 0
+        assert isinstance(
+            params.threshold_params,
+            ThresholdSelectionParameters,
+        )
+        assert isinstance(params.column_params, ColumnSelectionParameters)
+
+    @pytest.mark.parametrize(
+        "frac_subsamples,fail",
+        [
+            (-0.1, True),
+            (0.0, True),
+            (0.5, False),
+            (1.0, False),
+            (1.1, True),
+        ],
+    )
+    def test_frac_subsamples(self, frac_subsamples: float, fail: bool):
+        try:
+            _ = TreeGrowthParameters(
+                max_depth=10,
+                frac_subsamples=frac_subsamples,
+            )
+        except ValueError as ex:
+            if fail:
+                pass  # f"init with {frac_subsamples=} should fail: {ex}"
+            else:
+                pytest.fail(f"init with {frac_subsamples=} should fail: {ex}")
+        else:
+            if fail:
+                pytest.fail(f"init with {frac_subsamples=} should fail")
+
+    @pytest.mark.parametrize(
+        "frac_features,fail",
+        [
+            (-0.1, True),
+            (0.0, True),
+            (0.5, False),
+            (1.0, False),
+            (1.1, True),
+        ],
+    )
+    def test_frac_features(self, frac_features: float, fail: bool):
+        try:
+            _ = TreeGrowthParameters(
+                max_depth=10,
+                frac_features=frac_features,
+            )
+        except ValueError as ex:
+            if fail:
+                pass  # f"init with {frac_features=} should fail: {ex}"
+            else:
+                pytest.fail(f"init with {frac_features=} should fail: {ex}")
+        else:
+            if fail:
+                pytest.fail(f"init with {frac_features=} should fail")
+
+    def test_fail_if_max_depth_missing(self):
+        with pytest.raises(ValidationError):
+            _ = TreeGrowthParameters()  # type: ignore

--- a/tests/test_randomforest.py
+++ b/tests/test_randomforest.py
@@ -2,8 +2,11 @@ import numpy as np
 import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
-import random_tree_models.decisiontree as dtree
 import random_tree_models.randomforest as rf
+from random_tree_models.decisiontree import (
+    DecisionTreeClassifier,
+    DecisionTreeRegressor,
+)
 from tests.conftest import expected_failed_checks
 
 
@@ -36,9 +39,7 @@ class TestRandomForestRegressor:
     def test_fit(self):
         model = rf.RandomForestRegressor()
         model.fit(self.X, self.y)
-        assert all(
-            [isinstance(model, dtree.DecisionTreeRegressor) for model in model.trees_]
-        )
+        assert all([isinstance(model, DecisionTreeRegressor) for model in model.trees_])
 
     def test_predict(self):
         model = rf.RandomForestRegressor()
@@ -68,7 +69,7 @@ class TestXGBoostClassifier:
         model.fit(self.X, self.y)
         assert not hasattr(self.model, "classes_")
         assert all(
-            [isinstance(model, dtree.DecisionTreeClassifier) for model in model.trees_]
+            [isinstance(model, DecisionTreeClassifier) for model in model.trees_]
         )
 
     def test_predict(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,222 +1,9 @@
 import logging
 
 import pytest
-from pydantic import ValidationError
 
+import random_tree_models.utils
 import random_tree_models.utils as utils
-from random_tree_models.params import (
-    ColumnSelectionMethod,
-    ColumnSelectionParameters,
-    ThresholdSelectionMethod,
-    ThresholdSelectionParameters,
-    TreeGrowthParameters,
-)
-
-
-def test_ColumnSelectionMethod():
-    expected = ["ascending", "largest_delta", "random"]
-    assert list(ColumnSelectionMethod.__members__.keys()) == expected
-
-
-def test_ThresholdSelectionMethod():
-    expected = ["bruteforce", "quantile", "random", "uniform"]
-    assert list(ThresholdSelectionMethod.__members__.keys()) == expected
-
-
-# method, quantile, random_state, n_thresholds
-class TestThresholdSelectionParameters:
-    def test_expected_okay(self):
-        params = ThresholdSelectionParameters(
-            method=ThresholdSelectionMethod.quantile,
-            quantile=0.1,
-            random_state=0,
-            n_thresholds=100,
-        )
-        assert params.method == ThresholdSelectionMethod.quantile
-        assert params.quantile == 0.1
-        assert params.random_state == 0
-        assert params.n_thresholds == 100
-        assert params.num_quantile_steps == 11
-
-    def test_method_fail(self):
-        try:
-            _ = ThresholdSelectionParameters(
-                method="wuppy",  # type: ignore
-                quantile=0.1,
-                random_state=0,
-                n_thresholds=100,
-            )
-        except ValueError:
-            pass  # f"init with unknown method should fail: {ex}"
-        else:
-            raise
-
-    @pytest.mark.parametrize(
-        "q,fail",
-        [(-0.1, True), (0.0, True), (0.5, False), (1.0, True), (1.1, True)],
-    )
-    def test_quantile(self, q: float, fail: bool):
-        try:
-            _ = ThresholdSelectionParameters(
-                method=ThresholdSelectionMethod.quantile,
-                quantile=q,
-                random_state=0,
-                n_thresholds=100,
-            )
-        except ValueError as ex:
-            if fail:
-                pass  # f"init with quantile {q} should fail: {ex}"
-            else:
-                pytest.fail(f"init with quantile {q} should fail: {ex}")
-        else:
-            if fail:
-                raise
-
-    @pytest.mark.parametrize(
-        "random_state,fail",
-        [
-            (-1, True),
-            (0, False),
-            (1, False),
-        ],
-    )
-    def test_random_state(self, random_state: int, fail: bool):
-        try:
-            _ = ThresholdSelectionParameters(
-                method=ThresholdSelectionMethod.quantile,
-                quantile=0.1,
-                random_state=random_state,
-                n_thresholds=100,
-            )
-        except ValueError as ex:
-            if fail:
-                pass  # f"init with {random_state=} should fail: {ex}"
-            else:
-                pytest.fail(f"init with {random_state=} should fail: {ex}")
-        else:
-            if fail:
-                pytest.fail(f"init with {random_state=} should fail")
-
-    @pytest.mark.parametrize(
-        "n_thresholds,fail",
-        [
-            (-1, True),
-            (0, True),
-            (
-                1,
-                False,
-            ),
-            (10, False),
-        ],
-    )
-    def test_n_thresholds(self, n_thresholds: int, fail: bool):
-        try:
-            _ = ThresholdSelectionParameters(
-                method=ThresholdSelectionMethod.quantile,
-                quantile=0.1,
-                random_state=42,
-                n_thresholds=n_thresholds,
-            )
-        except ValueError as ex:
-            if fail:
-                pass  # f"init with {n_thresholds=} should fail: {ex}"
-            else:
-                pytest.fail(f"init with {n_thresholds=} should fail: {ex}")
-        else:
-            if fail:
-                raise
-
-
-def test_ColumnSelectionParameters():
-    params = ColumnSelectionParameters(method=ColumnSelectionMethod.random, n_trials=10)
-    assert params.method == ColumnSelectionMethod.random
-    assert params.n_trials == 10
-
-
-class TestTreeGrowthParameters:
-    def test_expected_okay(self):
-        params = TreeGrowthParameters(
-            max_depth=10,
-            min_improvement=0.0,
-            lam=0.0,
-            frac_subsamples=1.0,
-            frac_features=1.0,
-            random_state=0,
-            threshold_params=ThresholdSelectionParameters(
-                method=ThresholdSelectionMethod.quantile,
-                quantile=0.1,
-                random_state=0,
-                n_thresholds=100,
-            ),
-            column_params=ColumnSelectionParameters(
-                method=ColumnSelectionMethod.random, n_trials=10
-            ),
-        )
-        assert params.max_depth == 10
-        assert params.min_improvement == 0.0
-        assert params.lam == 0.0
-        assert params.frac_subsamples == 1.0
-        assert params.frac_features == 1.0
-        assert params.random_state == 0
-        assert isinstance(
-            params.threshold_params,
-            ThresholdSelectionParameters,
-        )
-        assert isinstance(params.column_params, ColumnSelectionParameters)
-
-    @pytest.mark.parametrize(
-        "frac_subsamples,fail",
-        [
-            (-0.1, True),
-            (0.0, True),
-            (0.5, False),
-            (1.0, False),
-            (1.1, True),
-        ],
-    )
-    def test_frac_subsamples(self, frac_subsamples: float, fail: bool):
-        try:
-            _ = TreeGrowthParameters(
-                max_depth=10,
-                frac_subsamples=frac_subsamples,
-            )
-        except ValueError as ex:
-            if fail:
-                pass  # f"init with {frac_subsamples=} should fail: {ex}"
-            else:
-                pytest.fail(f"init with {frac_subsamples=} should fail: {ex}")
-        else:
-            if fail:
-                pytest.fail(f"init with {frac_subsamples=} should fail")
-
-    @pytest.mark.parametrize(
-        "frac_features,fail",
-        [
-            (-0.1, True),
-            (0.0, True),
-            (0.5, False),
-            (1.0, False),
-            (1.1, True),
-        ],
-    )
-    def test_frac_features(self, frac_features: float, fail: bool):
-        try:
-            _ = TreeGrowthParameters(
-                max_depth=10,
-                frac_features=frac_features,
-            )
-        except ValueError as ex:
-            if fail:
-                pass  # f"init with {frac_features=} should fail: {ex}"
-            else:
-                pytest.fail(f"init with {frac_features=} should fail: {ex}")
-        else:
-            if fail:
-                pytest.fail(f"init with {frac_features=} should fail")
-
-    def test_fail_if_max_depth_missing(self):
-        with pytest.raises(ValidationError):
-            _ = TreeGrowthParameters()  # type: ignore
 
 
 def test_get_logger():
@@ -224,3 +11,28 @@ def test_get_logger():
     assert isinstance(logger, logging.Logger)
     assert logger.name == "rich"
     assert logger.level == logging.INFO
+
+
+@pytest.mark.parametrize(
+    "x,exp,is_bad",
+    [
+        (True, 1, False),
+        (False, -1, False),
+        ("a", None, True),
+        (1, 1, False),
+        (0, -1, False),
+        (-1, None, True),
+        (None, None, True),
+    ],
+)
+def test_bool_to_float(x, exp, is_bad: bool):
+    try:
+        # line to test
+        res = random_tree_models.utils.bool_to_float(x)
+    except ValueError as ex:
+        if is_bad:
+            pass  # Failed expectedly to convert non-bool values
+    else:
+        if is_bad:
+            pytest.fail(f"Passed unexpectedly for non-bool value {x} returning {res}")
+        assert res == exp

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
-import random_tree_models.decisiontree as dtree
 import random_tree_models.xgboost as xgboost
+from random_tree_models.decisiontree import DecisionTreeRegressor
 from tests.conftest import expected_failed_checks
 
 
@@ -36,9 +36,7 @@ class TestXGBoostRegressor:
     def test_fit(self):
         model = xgboost.XGBoostRegressor()
         model.fit(self.X, self.y)
-        assert all(
-            [isinstance(model, dtree.DecisionTreeRegressor) for model in model.trees_]
-        )
+        assert all([isinstance(model, DecisionTreeRegressor) for model in model.trees_])
 
     def test_predict(self):
         model = xgboost.XGBoostRegressor()
@@ -67,9 +65,7 @@ class TestXGBoostClassifier:
         model = xgboost.XGBoostClassifier()
         model.fit(self.X, self.y)
         assert not hasattr(self.model, "classes_")
-        assert all(
-            [isinstance(model, dtree.DecisionTreeRegressor) for model in model.trees_]
-        )
+        assert all([isinstance(model, DecisionTreeRegressor) for model in model.trees_])
 
     def test_predict(self):
         model = xgboost.XGBoostClassifier()


### PR DESCRIPTION
This pull request refactors imports and type references throughout the codebase to simplify and standardize the usage of parameters and utility functions. It also moves the `bool_to_float` utility function to a more appropriate location and updates related tests accordingly. No core logic is changed, but the codebase is now cleaner, with improved maintainability and clarity.

**Refactoring and Simplification of Imports and Type References:**

* Replaced all fully-qualified references to parameter types (such as `random_tree_models.params.MetricNames`) with direct imports and usage throughout `estimators.py` and `split.py`, making the code more concise and readable. [[1]](diffhunk://#diff-22eae66bd85aebbb718b4c9805d023a3632fecb59d41659870b8310e36ec1933L8-R18) [[2]](diffhunk://#diff-22eae66bd85aebbb718b4c9805d023a3632fecb59d41659870b8310e36ec1933L22-R53) [[3]](diffhunk://#diff-22eae66bd85aebbb718b4c9805d023a3632fecb59d41659870b8310e36ec1933L67-R86) [[4]](diffhunk://#diff-22eae66bd85aebbb718b4c9805d023a3632fecb59d41659870b8310e36ec1933L145-R154) [[5]](diffhunk://#diff-22eae66bd85aebbb718b4c9805d023a3632fecb59d41659870b8310e36ec1933L218-R227) [[6]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL5-R20) [[7]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL22-R31) [[8]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL33-R43) [[9]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL49-R56) [[10]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL80-R101) [[11]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL117-R124) [[12]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL144-R150) [[13]](diffhunk://#diff-8328b7e9c230b0f232452da128e195d71eee545a96b94935d1618547d2c45d9cL170-R176)

**Utility Function Relocation:**

* Moved the `bool_to_float` function from `gradientboostedtrees.py` to `utils.py`, and updated all usages and imports accordingly. [[1]](diffhunk://#diff-6ce46549b470217df9db627d93ec1e2e6d06a53a9d053058b2b0e4c872e49ddeL137-L145) [[2]](diffhunk://#diff-df37db600d4cc304cecab5a3174ccf26cec22e1ba57f6d85135174903f2bdb90R22-R30) [[3]](diffhunk://#diff-df7a850d9fe8f73bd541a32f7088f3acbfe3a5dfe46d478de8d12a7cc30ccbe5L30-R30)

**Test Updates and Cleanup:**

* Updated test files to import classes and parameters directly, removing unnecessary module-level imports and making type checks more explicit. [[1]](diffhunk://#diff-e42f5c62e45fbbd569016133ce4121a9d6188e13505630bda5a705c9eedf63f5L5-R9) [[2]](diffhunk://#diff-e42f5c62e45fbbd569016133ce4121a9d6188e13505630bda5a705c9eedf63f5L40-R43) [[3]](diffhunk://#diff-e42f5c62e45fbbd569016133ce4121a9d6188e13505630bda5a705c9eedf63f5L72-R73) [[4]](diffhunk://#diff-2de19897057048400bd973bca97349ae119946a10c55510b0ca4d465d26c0ec0L5-R8) [[5]](diffhunk://#diff-2de19897057048400bd973bca97349ae119946a10c55510b0ca4d465d26c0ec0L39-R41) [[6]](diffhunk://#diff-2de19897057048400bd973bca97349ae119946a10c55510b0ca4d465d26c0ec0L70-R70) [[7]](diffhunk://#diff-df81183bb94ebd2a0b1b43d79daa5280d37ee9244160895f82df70f944602fbbL5-R5) [[8]](diffhunk://#diff-df81183bb94ebd2a0b1b43d79daa5280d37ee9244160895f82df70f944602fbbL22-R28) [[9]](diffhunk://#diff-df81183bb94ebd2a0b1b43d79daa5280d37ee9244160895f82df70f944602fbbL39-R38)
* Removed the redundant and now unnecessary `test_bool_to_float` test, as the function is now a generic utility.…unch of other things