### PR TITLE
chore: bumped to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "random_tree_models"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "pyo3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "random_tree_models"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "random-tree-models"
-version = "0.7.2"
+version = "0.7.3"
 description = "Implementation of a random selection of tree based models."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2730,7 +2730,7 @@ wheels = [
 
 [[package]]
 name = "random-tree-models"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
This pull request updates the version numbers for the project in both the Rust and Python package configuration files to prepare for a new release.

Version bump for release:

* Updated the version in `Cargo.toml` from `0.7.2` to `0.7.3` to reflect a new Rust package release.
* Updated the version in `pyproject.toml` from `0.7.2` to `0.7.3` for the Python package.