### PR TITLE
chore: bumped to 0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "random_tree_models"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "pyo3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "random_tree_models"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "random-tree-models"
-version = "0.7.3"
+version = "0.7.4"
 description = "Implementation of a random selection of tree based models."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2730,7 +2730,7 @@ wheels = [
 
 [[package]]
 name = "random-tree-models"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
This pull request updates the version number for both the Rust and Python packages to prepare for a new release. There are no other changes included.

- Version bump:
  * Updated the version in `Cargo.toml` from `0.7.3` to `0.7.4` for the Rust crate.
  * Updated the version in `pyproject.toml` from `0.7.3` to `0.7.4` for the Python package.